### PR TITLE
queryIterable and queryIterableKeys now have an overloaded method that take a collection of filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ release.properties
 target/
 bin/
 tmp/
+.idea
+*.iml

--- a/mardao-core/src/main/java/net/sf/mardao/core/dao/DaoImpl.java
+++ b/mardao-core/src/main/java/net/sf/mardao/core/dao/DaoImpl.java
@@ -147,7 +147,7 @@ public abstract class DaoImpl<T, ID extends Serializable,
     
     /** Implemented in TypeDaoImpl */
     protected abstract Collection<C> persistCore(Iterable<E> itrbl);
-    
+
     /** Implemented in TypeDaoImpl */
     protected abstract CursorPage<T, ID> queryPage(boolean keysOnly, int pageSize,
             Object ancestorKey, Object primaryKey,
@@ -156,20 +156,57 @@ public abstract class DaoImpl<T, ID extends Serializable,
             Serializable cursorString,
             Filter... filters);
 
-    /** Implemented in TypeDaoImpl */
-    protected abstract Iterable<T> queryIterable(boolean keysOnly, 
+    /** Convenience method taking a variable number of filter input parameters */
+    protected Iterable<T> queryIterable(boolean keysOnly,
             int offset, int limit,
             Object ancestorKey, Object primaryKey,
             String primaryOrderBy, boolean primaryIsAscending,
             String secondaryOrderBy, boolean secondaryIsAscending,
-            Filter... filters);
+            Filter... filters) {
+
+        Collection<Filter> filterCollection = new ArrayList<Filter>();
+        for (Filter filter : filters) {
+            filterCollection.add(filter);
+        }
+
+        return queryIterable(keysOnly, offset, limit, ancestorKey, primaryKey,
+                primaryOrderBy, primaryIsAscending, secondaryOrderBy, secondaryIsAscending,
+                filterCollection);
+    }
+
+    /** Implemented in TypeDaoImpl */
+    protected abstract Iterable<T> queryIterable(
+            boolean keysOnly,
+            int offset, int limit,
+            Object ancestorKey, Object primaryKey,
+            String primaryOrderBy, boolean primaryIsAscending,
+            String secondaryOrderBy, boolean secondaryIsAscending,
+            Collection<Filter> filters);
+
+    /** Convenience method taking a variable number of filter input parameters */
+    protected Iterable<ID> queryIterableKeys(
+            int offset, int limit,
+            Object ancestorKey, Object primaryKey,
+            String primaryOrderBy, boolean primaryIsAscending,
+            String secondaryOrderBy, boolean secondaryIsAscending,
+            Filter... filters) {
+
+        Collection<Filter> filterCollection = new ArrayList<Filter>();
+        for (Filter filter : filters) {
+            filterCollection.add(filter);
+        }
+
+        return queryIterableKeys(offset, limit, ancestorKey, primaryKey,
+                primaryOrderBy, primaryIsAscending, secondaryOrderBy, secondaryIsAscending,
+                filterCollection);
+    }
 
     /** Implemented in TypeDaoImpl */
     protected abstract Iterable<ID> queryIterableKeys(int offset, int limit,
             Object ancestorKey, Object primaryKey,
             String primaryOrderBy, boolean primaryIsAscending,
             String secondaryOrderBy, boolean secondaryIsAscending,
-            Filter... filters);
+            Collection<Filter> filters);
 
     /** Implemented in TypeDaoImpl */
     protected abstract ID coreToSimpleKey(E core);

--- a/mardao-gae/src/main/java/net/sf/mardao/core/dao/TypeDaoImpl.java
+++ b/mardao-gae/src/main/java/net/sf/mardao/core/dao/TypeDaoImpl.java
@@ -327,7 +327,7 @@ public abstract class TypeDaoImpl<T, ID extends Serializable> extends
             Object ancestorKey, Object simpleKey,
             String primaryOrderBy, boolean primaryIsAscending,
             String secondaryOrderBy, boolean secondaryIsAscending,
-            Filter... filters) {
+            Collection<Filter> filters) {
         
         final PreparedQuery pq = prepare(keysOnly, (Key)ancestorKey, (Key)simpleKey, 
                               primaryOrderBy, primaryIsAscending, 
@@ -345,7 +345,7 @@ public abstract class TypeDaoImpl<T, ID extends Serializable> extends
             Object ancestorKey, Object simpleKey,
             String primaryOrderBy, boolean primaryIsAscending,
             String secondaryOrderBy, boolean secondaryIsAscending,
-            Filter... filters) {
+            Collection<Filter> filters) {
         
         final PreparedQuery pq = prepare(true, (Key)ancestorKey, (Key)simpleKey, 
                               primaryOrderBy, primaryIsAscending, 
@@ -434,10 +434,11 @@ public abstract class TypeDaoImpl<T, ID extends Serializable> extends
     }
 
     /**
-     * @param ascending
-     * @param orderBy
+     *
      * @param filters
-     * 
+     * @param orderBy
+     * @param direction
+     * @return
      */
     protected PreparedQuery prepare(Map<String, Object> filters, String orderBy, boolean direction) {
         return prepare(filters, orderBy, direction, null, false);
@@ -476,17 +477,34 @@ public abstract class TypeDaoImpl<T, ID extends Serializable> extends
         return datastore.prepare(q);
     }
 
+    // This method is here for backwards compatibility for old methods that still use variable length filter arguments
+    protected PreparedQuery prepare(boolean keysOnly, Key ancestorKey, Key simpleKey, String orderBy, boolean ascending,
+                                    String secondaryOrderBy, boolean secondaryAscending, Filter... filters) {
+
+        Collection<Filter> filterCollection = new ArrayList<Filter>();
+        for (Filter filter : filters) {
+            filterCollection.add(filter);
+        }
+
+        return prepare(keysOnly, ancestorKey, simpleKey,
+                orderBy, ascending, secondaryOrderBy, secondaryAscending,
+                filterCollection);
+    }
+
     /**
-     * 
+     *
      * @param keysOnly
-     * @param parentKey
+     * @param ancestorKey
+     * @param simpleKey
      * @param orderBy
      * @param ascending
+     * @param secondaryOrderBy
+     * @param secondaryAscending
      * @param filters
      * @return
      */
     protected PreparedQuery prepare(boolean keysOnly, Key ancestorKey, Key simpleKey, String orderBy, boolean ascending,
-            String secondaryOrderBy, boolean secondaryAscending, Filter... filters) {
+            String secondaryOrderBy, boolean secondaryAscending, Collection<Filter> filters) {
         LOG.debug("prepare {} with filters {}", getTableName(), filters);
         final DatastoreService datastore = getDatastoreService();
 

--- a/mardao-mysql/src/main/java/net/sf/mardao/core/dao/TypeDaoImpl.java
+++ b/mardao-mysql/src/main/java/net/sf/mardao/core/dao/TypeDaoImpl.java
@@ -588,11 +588,22 @@ public abstract class TypeDaoImpl<T, ID extends Serializable> extends
         return params;
     }
 
+    // This method is here for backward compatibility with old methods
+    protected Map<String, Object> appendWhereFilters(StringBuffer sql,
+                                                     Filter... filters) {
+
+        Collection<Filter> filterCollection = new ArrayList<Filter>();
+        for (Filter filter : filters) {
+            filterCollection.add(filter);
+        }
+
+        return appendWhereFilters(sql, filterCollection);
+    }
 
     protected Map<String, Object> appendWhereFilters(StringBuffer sql, 
-            Filter... filters) {
+            Collection<Filter> filters) {
         final Map<String, Object> params = new HashMap<String, Object>();
-        if (null == filters || 0 == filters.length) {
+        if (null == filters || 0 == filters.size()) {
             return params;
         }
         
@@ -821,13 +832,31 @@ public abstract class TypeDaoImpl<T, ID extends Serializable> extends
         return cursorPage;
     }
 
+    // This method is here for backward compatibility with old methods
+    protected Iterable<T> queryIterable(boolean keysOnly,
+                                        int offset, int limit,
+                                        Object ancestorKey, Object simpleKey,
+                                        String primaryOrderBy, boolean primaryIsAscending,
+                                        String secondaryOrderBy, boolean secondaryIsAscending,
+                                        Filter... filters) {
+
+        Collection<Filter> filterCollection = new ArrayList<Filter>();
+        for (Filter filter : filters) {
+            filterCollection.add(filter);
+        }
+
+        return queryIterable(keysOnly, offset, limit, ancestorKey, simpleKey,
+                primaryOrderBy, primaryIsAscending, secondaryOrderBy, secondaryIsAscending,
+                filterCollection);
+    }
+
     @Override
     protected Iterable<T> queryIterable(boolean keysOnly, 
             int offset, int limit,
             Object ancestorKey, Object simpleKey,
             String primaryOrderBy, boolean primaryIsAscending,
             String secondaryOrderBy, boolean secondaryIsAscending,
-            Filter... filters) {
+            Collection<Filter> filters) {
         if ((/* -1 == limit ||*/ 1000 < limit) && !keysOnly) {
             throw new UnsupportedOperationException("Not supported for Large Objects yet.");
         }
@@ -855,13 +884,31 @@ public abstract class TypeDaoImpl<T, ID extends Serializable> extends
         return domains;
     }
 
-    @Override
+    // This method is here for backward compatibility with old methods
     protected Iterable<ID> queryIterableKeys(
             int offset, int limit,
             Object ancestorKey, Object simpleKey,
             String primaryOrderBy, boolean primaryIsAscending,
             String secondaryOrderBy, boolean secondaryIsAscending,
             Filter... filters) {
+
+        Collection<Filter> filterCollection = new ArrayList<Filter>();
+        for (Filter filter : filters) {
+            filterCollection.add(filter);
+        }
+
+        return queryIterableKeys(offset, limit, ancestorKey, simpleKey,
+                primaryOrderBy, primaryIsAscending, secondaryOrderBy, secondaryIsAscending,
+                filterCollection);
+    }
+
+    @Override
+    protected Iterable<ID> queryIterableKeys(
+            int offset, int limit,
+            Object ancestorKey, Object simpleKey,
+            String primaryOrderBy, boolean primaryIsAscending,
+            String secondaryOrderBy, boolean secondaryIsAscending,
+            Collection<Filter> filters) {
         
         final StringBuffer sql = createSelect(true);
         


### PR DESCRIPTION
I ran into issues when I needed to create a variable number of filters depending on input parameters. If product id was provider use that as filter, if answer state was provided, user that as filter.

There is no easy way to create a dynamic number of filters in a single method and call a method that take a variable number of filter arguments (I need to make a dedicated call for each combination).

I added a new queryIterable and queryIterableKeys method that takes a Collection of filters. The change should be backwards compatible. Unit tests run and passing.

Could consider make this change to other methods that take variable length of filter parameters, I only did to these two methods.

Another option should maybe to allow the variable length method take filters set to null. Today this will cause a null pointer exception when preparing the query. You can check if the filter is null and then disregard. This will work as well and is a smaller change.

/Mattias
